### PR TITLE
debos: Fix FS type for boot partition for rpi

### DIFF
--- a/extra/debos/machine/rpi_2/actions.yaml
+++ b/extra/debos/machine/rpi_2/actions.yaml
@@ -23,7 +23,7 @@ actions:
         options: [x-systemd.automount]
     partitions:
       - name: firmware
-        fs: fat32
+        fs: vfat
         start: 0%
         end: 128MB
       - name: root


### PR DESCRIPTION
It used to work before, this regression was introduced in

https://github.com/go-debos/debos/pull/491

And fixed in later change:

https://github.com/go-debos/debos/pull/499

Observed issue on debos 1.1.4-1.1+b4 (debian testing)

    2025/01/05 17:48:40 Action `recipe` failed at stage Run, error: firmware mount failed: no such device
    2025/01/05 17:48:40 Warning: Failed to get unmount /boot/firmware: invalid argument
    2025/01/05 17:48:40 Unmount failure can cause images being incomplete!

Change-Id: Ie1c284256a88b5e3d757de82fe23fc8f848cfb75